### PR TITLE
Replace package names

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,9 +1,9 @@
 # Vim Script Parser written in Go
 
-[![Build Status](https://travis-ci.org/haya14busa/go-vimlparser.svg?branch=master)](https://travis-ci.org/haya14busa/go-vimlparser)
-[![codecov](https://codecov.io/gh/haya14busa/go-vimlparser/branch/master/graph/badge.svg)](https://codecov.io/gh/haya14busa/go-vimlparser)
-[![Sourcegraph](https://sourcegraph.com/github.com/haya14busa/go-vimlparser/-/badge.svg)](https://sourcegraph.com/github.com/haya14busa/go-vimlparser?badge)
-[![GoDoc](https://godoc.org/github.com/haya14busa/go-vimlparser?status.svg)](https://godoc.org/github.com/haya14busa/go-vimlparser)
+[![Build Status](https://travis-ci.org/vim-jp/go-vimlparser.svg?branch=master)](https://travis-ci.org/vim-jp/go-vimlparser)
+[![codecov](https://codecov.io/gh/vim-jp/go-vimlparser/branch/master/graph/badge.svg)](https://codecov.io/gh/vim-jp/go-vimlparser)
+[![Sourcegraph](https://sourcegraph.com/github.com/vim-jp/go-vimlparser/-/badge.svg)](https://sourcegraph.com/github.com/vim-jp/go-vimlparser?badge)
+[![GoDoc](https://godoc.org/github.com/vim-jp/go-vimlparser?status.svg)](https://godoc.org/github.com/vim-jp/go-vimlparser)
 
 This repository is the fork of https://github.com/ynkdir/vim-vimlparser and it provides Go-ish interface with performance improvement.
 
@@ -15,7 +15,7 @@ This repository is the fork of https://github.com/ynkdir/vim-vimlparser and it p
 
 ```sh
 $ pwd
-/home/haya14busa/src/github.com/ynkdir/vim-vimlparser
+/home/vim-jp/src/github.com/ynkdir/vim-vimlparser
 
 $ git rev-parse HEAD
 2fff43c58968a18bc01bc8304df68bde01af04d9
@@ -45,7 +45,7 @@ v4.2.3
 $ time node js/vimlparser.js autoload/vimlparser.vim > /dev/null
 node js/vimlparser.js autoload/vimlparser.vim > /dev/null  0.77s user 0.04s system 125% cpu 0.644 total
 
-$ go get github.com/haya14busa/go-vimlparser/cmd/vimlparser
+$ go get github.com/vim-jp/go-vimlparser/cmd/vimlparser
 $ time vimlparser autoload/vimlparser.vim > /dev/null
 vimlparser autoload/vimlparser.vim > /dev/null  0.25s user 0.03s system 114% cpu 0.244 total
 ```
@@ -59,25 +59,25 @@ vimlparser autoload/vimlparser.vim > /dev/null  0.25s user 0.03s system 114% cpu
 | node | 0.77s |
 | Go | **0.25s** |
 
-Note that, in addition to the Go lang speed, I added [performance improvement](https://github.com/haya14busa/go-vimlparser/pull/4) for Go implementation.
+Note that, in addition to the Go lang speed, I added [performance improvement](https://github.com/vim-jp/go-vimlparser/pull/4) for Go implementation.
 
 ### Rich interface compared to other implementation
 
 go-vimlparser is written in Go which is typed language and I added Go-ish interface,
-so you can see each node fields. e.g. https://godoc.org/github.com/haya14busa/go-vimlparser/ast#Function
+so you can see each node fields. e.g. https://godoc.org/github.com/vim-jp/go-vimlparser/ast#Function
 
 | package | doc |
 | --- | --- |
-| go-vimlparser | [![GoDoc](https://godoc.org/github.com/haya14busa/go-vimlparser?status.svg)](https://godoc.org/github.com/haya14busa/go-vimlparser) |
-| go-vimlparser/ast | [![GoDoc](https://godoc.org/github.com/haya14busa/go-vimlparser/ast?status.svg)](https://godoc.org/github.com/haya14busa/go-vimlparser/ast) |
-| go-vimlparser/token | [![GoDoc](https://godoc.org/github.com/haya14busa/go-vimlparser/token?status.svg)](https://godoc.org/github.com/haya14busa/go-vimlparser/token) |
+| go-vimlparser | [![GoDoc](https://godoc.org/github.com/vim-jp/go-vimlparser?status.svg)](https://godoc.org/github.com/vim-jp/go-vimlparser) |
+| go-vimlparser/ast | [![GoDoc](https://godoc.org/github.com/vim-jp/go-vimlparser/ast?status.svg)](https://godoc.org/github.com/vim-jp/go-vimlparser/ast) |
+| go-vimlparser/token | [![GoDoc](https://godoc.org/github.com/vim-jp/go-vimlparser/token?status.svg)](https://godoc.org/github.com/vim-jp/go-vimlparser/token) |
 
 ### CLI tool
 
 #### Installation
 
 ```
-go get github.com/haya14busa/go-vimlparser/cmd/vimlparser
+go get github.com/vim-jp/go-vimlparser/cmd/vimlparser
 ```
 
 #### Usage
@@ -129,4 +129,7 @@ augroup END
 [@ynkdir](https://github.com/ynkdir) for https://github.com/ynkdir/vim-vimlparser
 
 ### :bird: Author
-haya14busa (https://github.com/haya14busa)
+
+Original Author: haya14busa (https://github.com/haya14busa)
+
+Maintenance Author: vim-jp

--- a/ast/example_test.go
+++ b/ast/example_test.go
@@ -6,8 +6,8 @@ import (
 
 	"strings"
 
-	"github.com/haya14busa/go-vimlparser"
-	"github.com/haya14busa/go-vimlparser/ast"
+	"github.com/vim-jp/go-vimlparser"
+	"github.com/vim-jp/go-vimlparser/ast"
 )
 
 // This example demonstrates how to inspect the AST of a Go program.

--- a/ast/node.go
+++ b/ast/node.go
@@ -3,7 +3,7 @@
 package ast
 
 import (
-	"github.com/haya14busa/go-vimlparser/token"
+	"github.com/vim-jp/go-vimlparser/token"
 )
 
 // Node is the interface for all node types to implement.

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -28,7 +28,7 @@ func Walk(v Visitor, node Node) {
 	// walk children
 	// (the order of the cases matches the order
 	// of the corresponding node types in newAstNode func
-	// in github.com/haya14busa/go-vimlparser/go/export.go)
+	// in github.com/vim-jp/go-vimlparser/go/export.go)
 	switch n := node.(type) {
 	case *File:
 		walkStmtList(v, n.Body)

--- a/ast/walk_test.go
+++ b/ast/walk_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/haya14busa/go-vimlparser"
-	"github.com/haya14busa/go-vimlparser/ast"
+	"github.com/vim-jp/go-vimlparser"
+	"github.com/vim-jp/go-vimlparser/ast"
 )
 
 func TestInspect(t *testing.T) {

--- a/cmd/vimlparser/main.go
+++ b/cmd/vimlparser/main.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/haya14busa/go-vimlparser"
-	"github.com/haya14busa/go-vimlparser/compiler"
+	"github.com/vim-jp/go-vimlparser"
+	"github.com/vim-jp/go-vimlparser/compiler"
 )
 
 var neovim = flag.Bool("neovim", false, "use neovim parser")

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -9,8 +9,8 @@ import (
 	"io"
 	"strings"
 
-	"github.com/haya14busa/go-vimlparser/ast"
-	"github.com/haya14busa/go-vimlparser/token"
+	"github.com/vim-jp/go-vimlparser/ast"
+	"github.com/vim-jp/go-vimlparser/token"
 )
 
 // Config for Compiler.

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/haya14busa/go-vimlparser"
+	"github.com/vim-jp/go-vimlparser"
 )
 
 var skipTests = map[string]bool{

--- a/go/export.go
+++ b/go/export.go
@@ -3,8 +3,8 @@ package vimlparser
 import (
 	"fmt"
 
-	"github.com/haya14busa/go-vimlparser/ast"
-	"github.com/haya14busa/go-vimlparser/token"
+	"github.com/vim-jp/go-vimlparser/ast"
+	"github.com/vim-jp/go-vimlparser/token"
 )
 
 // Parse parses Vim script in reader and returns Node.

--- a/go/vimlparser_test.go
+++ b/go/vimlparser_test.go
@@ -85,7 +85,7 @@ func TestVimLParser_parse(t *testing.T) {
 	}
 }
 
-const basePkg = "github.com/haya14busa/go-vimlparser/go"
+const basePkg = "github.com/vim-jp/go-vimlparser/go"
 
 var skipTests = map[string]bool{
 	"test_xxx_colonsharp": true,

--- a/printer/expr.go
+++ b/printer/expr.go
@@ -3,8 +3,8 @@ package printer
 import (
 	"fmt"
 
-	"github.com/haya14busa/go-vimlparser/ast"
-	"github.com/haya14busa/go-vimlparser/token"
+	"github.com/vim-jp/go-vimlparser/ast"
+	"github.com/vim-jp/go-vimlparser/token"
 )
 
 func (p *printer) expr(expr ast.Expr) {

--- a/printer/expr_test.go
+++ b/printer/expr_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	vimlparser "github.com/haya14busa/go-vimlparser"
-	"github.com/haya14busa/go-vimlparser/ast"
-	"github.com/haya14busa/go-vimlparser/token"
+	vimlparser "github.com/vim-jp/go-vimlparser"
+	"github.com/vim-jp/go-vimlparser/ast"
+	"github.com/vim-jp/go-vimlparser/token"
 )
 
 func TestFprint_expr(t *testing.T) {

--- a/printer/opprec.go
+++ b/printer/opprec.go
@@ -3,8 +3,8 @@ package printer
 import (
 	"fmt"
 
-	"github.com/haya14busa/go-vimlparser/ast"
-	"github.com/haya14busa/go-vimlparser/token"
+	"github.com/vim-jp/go-vimlparser/ast"
+	"github.com/vim-jp/go-vimlparser/token"
 )
 
 // opprec returns operator precedence. See also go/gocompiler.vim

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/haya14busa/go-vimlparser/ast"
-	"github.com/haya14busa/go-vimlparser/token"
+	"github.com/vim-jp/go-vimlparser/ast"
+	"github.com/vim-jp/go-vimlparser/token"
 )
 
 type whiteSpace byte

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/haya14busa/go-vimlparser"
+	"github.com/vim-jp/go-vimlparser"
 )
 
 func TestFprint_file(t *testing.T) {

--- a/vimlparser.go
+++ b/vimlparser.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/haya14busa/go-vimlparser/ast"
-	internal "github.com/haya14busa/go-vimlparser/go"
+	"github.com/vim-jp/go-vimlparser/ast"
+	internal "github.com/vim-jp/go-vimlparser/go"
 )
 
 // ErrVimlParser represents VimLParser error.

--- a/vimlparser_test.go
+++ b/vimlparser_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/haya14busa/go-vimlparser/compiler"
+	"github.com/vim-jp/go-vimlparser/compiler"
 )
 
 func TestParseFile_can_parse(t *testing.T) {


### PR DESCRIPTION
Replace all package names from haya14busa/go-vimlparser to vim-jp/go-vimlparser.